### PR TITLE
Ssmith/kil 3238 change azure function runtime to 15 min

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -243,6 +243,7 @@ resource "azurerm_linux_function_app" "mcd_agent_service_with_remote_upgrade_sup
       app_settings["FUNCTIONS_WORKER_PROCESS_COUNT"],
       app_settings["PYTHON_THREADPOOL_THREAD_COUNT"],
       app_settings["AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions"],
+      app_settings["AzureFunctionsJobHost__functionTimeout"],
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ locals {
     FUNCTIONS_WORKER_PROCESS_COUNT                                                 = 5
     PYTHON_THREADPOOL_THREAD_COUNT                                                 = 5
     AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions = 20
+    AzureFunctionsJobHost__functionTimeout                                         = "00:15:00"
 
     # MC properties and configuration
     MCD_AGENT_IMAGE_TAG       = var.image


### PR DESCRIPTION
- Requests coming from MC to the Agent have a timeout of 15 min so we can stop Azure Functions from running longer than 15 min as well

- Tested executing a query directly in the agent that will take 17 minutes. Before it completes:
<img width="666" alt="Screenshot 2024-02-26 at 10 44 00 AM" src="https://github.com/monte-carlo-data/terraform-azurerm-mcd-agent/assets/97194436/207f20b1-4274-4179-86b3-e5c5389e6a12">

- After this change it fails:
<img width="854" alt="Screenshot 2024-02-26 at 11 04 16 AM" src="https://github.com/monte-carlo-data/terraform-azurerm-mcd-agent/assets/97194436/7ca52013-2b08-4606-901e-ae945a9f0431">
