### PR TITLE
MES-795: restrict Terraform Azure provider max version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Wrapper metadata
-  mcd_wrapper_version       = "1.0.1"
+  mcd_wrapper_version       = "1.0.2"
   mcd_agent_platform        = "AZURE"
   mcd_agent_service_name    = "REMOTE_AGENT"
   mcd_agent_deployment_type = "TERRAFORM"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.75"
+      version = ">= 3.75, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
- We started getting an error when the latest Azure provider version (> 4.0) is used, as they made "subscriptionId" a required field when defining the Azure provider
- This PR sets the max version to the less than `4.0` to avoid that error
- Wrapper version increased to `1.0.2`